### PR TITLE
Remove DEBUG version

### DIFF
--- a/System.Ben.sln
+++ b/System.Ben.sln
@@ -9,9 +9,6 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "System.Ben.Tests", "tests\S
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
-		Debug|Any CPU = Debug|Any CPU
-		Debug|x64 = Debug|x64
-		Debug|x86 = Debug|x86
 		Release|Any CPU = Release|Any CPU
 		Release|x64 = Release|x64
 		Release|x86 = Release|x86
@@ -19,25 +16,13 @@ Global
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
 	EndGlobalSection
-	GlobalSection(ProjectConfigurationPlatforms) = postSolution
-		{F7742808-35E7-4553-81DA-428CEC177EF0}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{F7742808-35E7-4553-81DA-428CEC177EF0}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{F7742808-35E7-4553-81DA-428CEC177EF0}.Debug|x64.ActiveCfg = Debug|x64
-		{F7742808-35E7-4553-81DA-428CEC177EF0}.Debug|x64.Build.0 = Debug|x64
-		{F7742808-35E7-4553-81DA-428CEC177EF0}.Debug|x86.ActiveCfg = Debug|x86
-		{F7742808-35E7-4553-81DA-428CEC177EF0}.Debug|x86.Build.0 = Debug|x86
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution		
 		{F7742808-35E7-4553-81DA-428CEC177EF0}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{F7742808-35E7-4553-81DA-428CEC177EF0}.Release|Any CPU.Build.0 = Release|Any CPU
 		{F7742808-35E7-4553-81DA-428CEC177EF0}.Release|x64.ActiveCfg = Release|x64
 		{F7742808-35E7-4553-81DA-428CEC177EF0}.Release|x64.Build.0 = Release|x64
 		{F7742808-35E7-4553-81DA-428CEC177EF0}.Release|x86.ActiveCfg = Release|x86
 		{F7742808-35E7-4553-81DA-428CEC177EF0}.Release|x86.Build.0 = Release|x86
-		{4F4B83E1-DE54-4172-A1AD-3A1370471873}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{4F4B83E1-DE54-4172-A1AD-3A1370471873}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{4F4B83E1-DE54-4172-A1AD-3A1370471873}.Debug|x64.ActiveCfg = Debug|x64
-		{4F4B83E1-DE54-4172-A1AD-3A1370471873}.Debug|x64.Build.0 = Debug|x64
-		{4F4B83E1-DE54-4172-A1AD-3A1370471873}.Debug|x86.ActiveCfg = Debug|x86
-		{4F4B83E1-DE54-4172-A1AD-3A1370471873}.Debug|x86.Build.0 = Debug|x86
 		{4F4B83E1-DE54-4172-A1AD-3A1370471873}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{4F4B83E1-DE54-4172-A1AD-3A1370471873}.Release|Any CPU.Build.0 = Release|Any CPU
 		{4F4B83E1-DE54-4172-A1AD-3A1370471873}.Release|x64.ActiveCfg = Release|x64


### PR DESCRIPTION
Two reasons

- DEBUG = **UNOPTIMISED** (😱)
- This code is perfect, it will never need debugging, to suggest otherwise implies weakness!