### PR TITLE
Add bash build script

### DIFF
--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+set -e
+
+scriptsFolder="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+projectRootFolder="$(dirname "$scriptsFolder")"
+cd $projectRootFolder
+
+#restoring packages 
+dotnet restore
+
+#running tests
+dotnet test $projectRootFolder/tests/System.Ben.Tests.csproj
+
+#building solutions
+dotnet build -c Release
+


### PR DESCRIPTION
Because you can't have proper cross-platform support without a `build.sh` & `build.ps1`