### PR TITLE
Fix dotnet-cli errors from `dotnet test`

### DIFF
--- a/tests/System.Ben.Tests.csproj
+++ b/tests/System.Ben.Tests.csproj
@@ -1,11 +1,15 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard1.0</TargetFramework>
+    <TargetFramework>netcoreapp1.1</TargetFramework>
   </PropertyGroup>
   
   <ItemGroup>
     <ProjectReference Include="..\src\System.Ben.csproj" />
   </ItemGroup>
-
+  <ItemGroup>
+    <PackageReference Include="xunit" Version="2.2.0" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.2.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.0.0" />
+  </ItemGroup>
 </Project>

--- a/tests/Tests.cs
+++ b/tests/Tests.cs
@@ -1,0 +1,6 @@
+using Xunit;
+public class Tests
+{
+    [Fact(Skip = "yes, it is")]
+    public void IsSuperFastAndSuperSecure() {}
+}


### PR DESCRIPTION
Running `dotnet test` currently gives failure messages:

    Starting test execution, please wait...
    Could not find testhost.dll for source 'C:\code\System.Ben\tests\bin\Debug\netstandard1.0\System.Ben.Tests.dll'. Make sure test project has a nuget reference of package "microsoft.testplatform.testhost".

This is clearly sub-optimal and needs fixing; the *perfect* fix is sadly hampered by a bug in xunit/VSTest.Console, which gives the following incorrect result:

    No test is available in C:\code\System.Ben\tests\bin\Debug\netcoreapp1.1\System.Ben.Tests.dll. Make sure that installed test discoverers & executors, platform & framework version settings are appropriate and try again.

I have therefore used a workaround with:

    Total tests: 1. Passed: 0. Failed: 0. Skipped: 1.
    Test Run Successful.
    Test execution time: 1.5873 Seconds